### PR TITLE
Update store action behaviour and refactor

### DIFF
--- a/starlingcaptureapi/actions.py
+++ b/starlingcaptureapi/actions.py
@@ -25,6 +25,9 @@ class Actions:
             asset_fullpath: the local path to the asset file
             jwt_payload: a JWT payload containing metadata
             meta: dictionary with the 'meta' section of the incoming multipart request
+
+        Returns:
+            the local path to the asset file in the internal directory
         """
         # Create temporary files to work with.
         tmp_asset_file = _asset_helper.get_tmp_file_fullpath(".jpg")
@@ -40,13 +43,8 @@ class Actions:
                     tmp_asset_file
                 )
                 shutil.move(tmp_asset_file, internal_asset_file)
-                shutil.copy2(
-                    internal_asset_file, _asset_helper.get_assets_create_output()
-                )
-                _logger.info(
-                    "New asset file added to the internal and shared assets directories: %s",
-                    internal_asset_file,
-                )
+                shutil.copy2(internal_asset_file, _asset_helper.get_assets_create_output())
+                _logger.info("New asset file added: %s", internal_asset_file)
                 internal_claim_file = _asset_helper.get_internal_claim_fullpath(
                     internal_asset_file
                 )
@@ -57,8 +55,9 @@ class Actions:
                 )
                 return
         _logger.error(
-            "Failed to process asset with the create action: %s", asset_fullpath
+            "Failed to process asset with the create() action: %s", asset_fullpath
         )
+        return internal_asset_file
 
     def add(self, asset_fullpath):
         """Process asset with add action.
@@ -66,16 +65,11 @@ class Actions:
 
         Args:
             asset_fullpath: the local path to the asset file
+
+        Returns:
+            the local path to the asset file in the internal directory
         """
-        # Copy asset to both the internal and shared asset directories.
-        internal_file = _asset_helper.get_internal_file_fullpath(asset_fullpath)
-        shutil.move(asset_fullpath, internal_file)
-        shutil.copy2(internal_file, _asset_helper.get_assets_add_output())
-        _logger.info(
-            "New file added to the internal and shared assets directories: %s",
-            internal_file,
-        )
-        # TODO(ben): handle file errors
+        return self._add(asset_fullpath, _asset_helper.get_assets_add_output())
 
     def update(self, asset_fullpath):
         """Process asset with update action.
@@ -83,7 +77,51 @@ class Actions:
 
         Args:
             asset_fullpath: the local path to the asset file
+
+        Returns:
+            the local path to the asset file in the internal directory
         """
+        return self._update(asset_fullpath, _claim.generate_update(), _asset_helper.get_assets_update_output())
+
+    def store(self, asset_fullpath):
+        """Process asset with store action.
+        The provided asset stored on decentralized storage, then a new asset file is generated in the store-output folder with a storage claim.
+
+        Args:
+            asset_fullpath: the local path to the asset file
+
+        Returns:
+            the local path to the asset file in the internal directory
+        """
+        # Add uploaded asset to the internal directory.
+        added_asset = self._add(asset_fullpath, None)
+
+        # Store asset to IPFS and Filecoin.
+        ipfs_cid = _filecoin.upload(added_asset)
+        _logger.info("Asset file uploaded to IPFS with CID: %s", ipfs_cid)
+
+        # TODO: This will always be None at this point. Here only for demonstration purposes.
+        # maybe_pieceCid = _filecoin.get_status(cid)
+        # _logger.info(f"PieceCID: {maybe_pieceCid}")
+
+        return self._update(added_asset, _claim.generate_store(ipfs_cid), _asset_helper.get_assets_store_output())
+
+
+    def _add(self, asset_fullpath, output_dir):
+        # Create temporary files to work with.
+        tmp_asset_file = _asset_helper.get_tmp_file_fullpath(".jpg")
+        shutil.copy2(asset_fullpath, tmp_asset_file)
+
+        # Copy asset to both the internal and shared asset directories.
+        internal_asset_file = _asset_helper.get_internal_file_fullpath(tmp_asset_file)
+        shutil.move(tmp_asset_file, internal_asset_file)
+        if output_dir:
+            shutil.copy2(internal_asset_file, output_dir)
+        _logger.info("New asset file added: %s", internal_asset_file)
+        # TODO(ben): handle file errors
+        return internal_asset_file
+
+    def _update(self, asset_fullpath, claim, output_dir):
         # Create temporary files to work with.
         tmp_asset_file = _asset_helper.get_tmp_file_fullpath(".jpg")
         tmp_claim_file = _asset_helper.get_tmp_file_fullpath(".json")
@@ -96,11 +134,10 @@ class Actions:
         )
 
         # Inject update claim and read back from file.
-        claim = _claim.generate_update()
         shutil.copy2(asset_fullpath, tmp_asset_file)
         _logger.info("Searching for parent file: %s", parent_file)
         if os.path.isfile(parent_file):
-            _logger.info("Update action found parent file for asset: %s", parent_file)
+            _logger.info("_update() action found parent file for asset: %s", parent_file)
             if _claim_tool.run_claim_inject(claim, tmp_asset_file, parent_file):
                 if _claim_tool.run_claim_dump(tmp_asset_file, tmp_claim_file):
                     # Copy the C2PA-injected asset to both the internal and shared asset directories.
@@ -108,13 +145,9 @@ class Actions:
                         tmp_asset_file
                     )
                     shutil.move(tmp_asset_file, internal_asset_file)
-                    shutil.copy2(
-                        internal_asset_file, _asset_helper.get_assets_update_output()
-                    )
-                    _logger.info(
-                        "New asset file added to the internal and shared assets directories: %s",
-                        internal_asset_file,
-                    )
+                    if output_dir:
+                        shutil.copy2(internal_asset_file, output_dir)
+                    _logger.info("New asset file added: %s", internal_asset_file)
                     internal_claim_file = _asset_helper.get_internal_claim_fullpath(
                         internal_asset_file
                     )
@@ -125,72 +158,10 @@ class Actions:
                     )
                     return
             _logger.error(
-                "Failed to process asset with the update action: %s", asset_fullpath
+                "Failed to process asset with the _update() action: %s", asset_fullpath
             )
         else:
             _logger.error(
-                "Update action found no parent file for asset: %s", asset_fullpath
+                "_update() action found no parent file for asset: %s", asset_fullpath
             )
-
-    def store(self, asset_fullpath):
-        """Process asset with store action.
-        The provided asset stored on decentralized storage, then a new asset file is generated in the store-output folder with a storage claim.
-
-        Args:
-            asset_fullpath: the local path to the asset file
-        """
-        # Store asset to IPFS and Filecoin.
-        ipfs_cid = _filecoin.upload(asset_fullpath)
-        _logger.info("Asset file uploaded to IPFS with CID: %s", ipfs_cid)
-
-        # TODO: This will always be None at this point. Here only for demonstration purposes.
-        # maybe_pieceCid = _filecoin.get_status(cid)
-        # _logger.info(f"PieceCID: {maybe_pieceCid}")
-
-        # Create temporary files to work with.
-        tmp_asset_file = _asset_helper.get_tmp_file_fullpath(".jpg")
-        tmp_claim_file = _asset_helper.get_tmp_file_fullpath(".json")
-
-        # Parse file name to get internal name for parent file.
-        file_name, file_extension = os.path.splitext(os.path.basename(asset_fullpath))
-        parent_file = os.path.join(
-            _asset_helper.get_assets_internal(),
-            file_name.partition("_")[0].partition("-")[0] + file_extension,
-        )
-
-        # Inject store claim and read back from file.
-        claim = _claim.generate_store(ipfs_cid)
-        shutil.copy2(asset_fullpath, tmp_asset_file)
-        _logger.info("Searching for parent file: %s", parent_file)
-        if os.path.isfile(parent_file):
-            _logger.info("Store action found parent file for asset: %s", parent_file)
-            if _claim_tool.run_claim_inject(claim, tmp_asset_file, parent_file):
-                if _claim_tool.run_claim_dump(tmp_asset_file, tmp_claim_file):
-                    # Copy the C2PA-injected asset to both the internal and shared asset directories.
-                    internal_asset_file = _asset_helper.get_internal_file_fullpath(
-                        tmp_asset_file
-                    )
-                    shutil.move(tmp_asset_file, internal_asset_file)
-                    shutil.copy2(
-                        internal_asset_file, _asset_helper.get_assets_store_output()
-                    )
-                    _logger.info(
-                        "New asset file added to the internal and shared assets directories: %s",
-                        internal_asset_file,
-                    )
-                    internal_claim_file = _asset_helper.get_internal_claim_fullpath(
-                        internal_asset_file
-                    )
-                    shutil.move(tmp_claim_file, internal_claim_file)
-                    _logger.info(
-                        "New claim file added to the internal claims directory: %s",
-                        internal_claim_file,
-                    )
-                    return
-            _logger.error(
-                "Failed to process asset with the store action: %s", asset_fullpath
-            )
-        else:
-            _logger.error(
-                "Store action found no parent file for asset: %s", asset_fullpath
-            )
+        return internal_asset_file


### PR DESCRIPTION
The `store` action was not implemented correctly. It used to use the file name to find its parent then make a claim on top of that. That's wrong.

Instead it needs to add the new file, ignore its file name, then make a claim on top of the newly added file.

This also allows refactoring `store` to just use `add` -> pin -> `update`. This patch does that.