### PR TITLE
Add more error handling and logging

### DIFF
--- a/starlingcaptureapi/claim_tool.py
+++ b/starlingcaptureapi/claim_tool.py
@@ -18,11 +18,10 @@ class ClaimTool:
             asset_fullpath: the local path to the asset file
             parent_asset_fullpath: local path to the parent asset file; or None
 
-        Returns:
-            True if successful; False if errored
+        Raises:
+            Exception if something goes wrong with injection
         """
-        arg = None
-        if parent_asset_fullpath == None:
+        if parent_asset_fullpath is None:
             args = [
                 config.CLAIM_TOOL_PATH,
                 "--claimdef",
@@ -43,10 +42,9 @@ class ClaimTool:
         popen = subprocess.Popen(args, stdout=subprocess.PIPE)
         popen.wait()
         if popen.returncode != 0:
-            _logger.error("claim_tool returned code %d", popen.returncode)
-            _logger.error("claim_tool output:\n %s", popen.stdout.read())
-            return False
-        return True
+            raise Exception(
+                f"claim_tool failed with code {popen.returncode} and output: {popen.stdout.read()}"
+            )
 
     def run_claim_dump(self, asset_fullpath, claim_fullpath):
         """Write claim information of an asset to a file.
@@ -55,8 +53,8 @@ class ClaimTool:
             asset_fullpath: the local path to the asset file
             claim_fullpath: the local path to write claim information
 
-        Returns:
-            True if successful; False if errored
+        Raises:
+            Exception if errors are encountered
         """
         args = [
             config.CLAIM_TOOL_PATH,
@@ -67,7 +65,6 @@ class ClaimTool:
             popen = subprocess.Popen(args, stdout=claim_file)
             popen.wait()
             if popen.returncode != 0:
-                _logger.error("claim_tool returned code %d", popen.returncode)
-                _logger.error("claim_tool output:\n %s", popen.stdout.read())
-                return False
-        return True
+                raise Exception(
+                    f"claim_tool failed with code {popen.returncode} and output: {popen.stdout.read()}"
+                )

--- a/starlingcaptureapi/handlers.py
+++ b/starlingcaptureapi/handlers.py
@@ -3,18 +3,27 @@ from .multipart import Multipart
 
 from aiohttp import web
 
+import logging
+import traceback
+
+_logger = logging.getLogger(__name__)
 
 async def create(request):
     data = await Multipart().read(request)
-    Actions().create(
-        data.get("asset_fullpath"), request["jwt_payload"], data.get("meta")
-    )
-
-    # TODO(anaulin): Add error handling.
-    # TODO(anaulin): Add all the required metadata, errors, etc, to response.
+    status = 200
     response = {
-        "result": "ok",
-        "asset_fullpath": data["asset_fullpath"],
-        "jwt_payload": request["jwt_payload"],
+        "asset_fullpath": data.get("asset_fullpath"),
+        "jwt_payload": request.get("jwt_payload"),
     }
-    return web.json_response(response)
+    try:
+        Actions().create(
+            data.get("asset_fullpath"), request.get("jwt_payload"), data.get("meta")
+        )
+    except Exception as err:
+        print(traceback.format_exc())
+        _logger.error(err)
+        status = 500
+        response["error"] = f"{err}"
+
+    # TODO(anaulin): Add all the required metadata, errors, etc, to response.
+    return web.json_response(response, status=status)


### PR DESCRIPTION
More progress on https://github.com/starlinglab/starling-capture-api/issues/2

This PR sketches out an error handling strategy: all non-recoverable errors should raise exceptions. Exceptions are caught and logged at the top level by either the API handlers or the `FsWatcher` handlers, and logged appropriately. In the case of an exception caught by an API handler, the response code is set to 500, and the error message is returned in the response.

One advantage of this approach is that we don't need to check for success of any actions where the error is not recoverable, and instead we can let the exception propagate to the top.