### PR TITLE
Race condition patch

### DIFF
--- a/starlingcaptureapi/actions.py
+++ b/starlingcaptureapi/actions.py
@@ -40,6 +40,7 @@ class Actions:
         # Inject create claim and read back from file.
         claim = _claim.generate_create(jwt_payload, meta)
         time.sleep(1)
+        _logger.info("File size: %s", os.path.getsize(asset_fullpath))
         shutil.copy2(asset_fullpath, tmp_asset_file)
         _claim_tool.run_claim_inject(claim, tmp_asset_file, None)
         _claim_tool.run_claim_dump(tmp_asset_file, tmp_claim_file)
@@ -114,6 +115,7 @@ class Actions:
         # Create temporary files to work with.
         tmp_asset_file = _asset_helper.get_tmp_file_fullpath(".jpg")
         time.sleep(1)
+        _logger.info("File size: %s", os.path.getsize(asset_fullpath))
         shutil.copy2(asset_fullpath, tmp_asset_file)
 
         # Copy asset to both the internal and shared asset directories.
@@ -139,6 +141,7 @@ class Actions:
 
         # Inject update claim and read back from file.
         time.sleep(1)
+        _logger.info("File size: %s", os.path.getsize(asset_fullpath))
         shutil.copy2(asset_fullpath, tmp_asset_file)
         _logger.info("Searching for parent file: %s", parent_file)
         if not os.path.isfile(parent_file):


### PR DESCRIPTION
There seems to be a race condition between `pyftpsync` writing the file and the `api` service picking up the file. At times it picks up the file when it is only partially written creating a corrupted file

Added sleep(1) before the first `shutil.copy2` will reduce the chance the file is not completely written when the `api` picks it up.

Also added a log line to be able to check if size was not what was expected.