### PR TITLE
Ignore local claim_tool/ binary directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dmypy.json
 
 # MacOS
 .DS_Store
+
+# Local claim_tool binary
+claim_tool/


### PR DESCRIPTION
A small developer quality-of-life improvement, to make it easier to keep around a `claim_tool` binary for development.