### PR TITLE
Adapt to new configuration schema 

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -8,7 +8,7 @@
           "asset_extensions": ["jpg", "jpeg"],
           "actions": [
             {
-              "name": "update",
+              "name": "c2pa-update",
               "params": {
                 "signer": "starlinglab-c2pa",
                 "creative_work_author": [

--- a/config.example.json
+++ b/config.example.json
@@ -4,7 +4,7 @@
       "id": "hyphacoop",
       "collections": [
         {
-          "id": "hypha-capture-test",
+          "id": "example-collection-hypha-capture",
           "asset_extensions": ["jpg", "jpeg"],
           "actions": [
             {

--- a/starlingcaptureapi/actions.py
+++ b/starlingcaptureapi/actions.py
@@ -144,7 +144,7 @@ class Actions:
         )
         return internal_asset_file
 
-    def add(self, asset_fullpath, org_config, collection_id):
+    def c2pa_add(self, asset_fullpath, org_config, collection_id):
         """Process asset with add action.
         The provided asset file is added to the asset management system and renamed to its internal identifier in the add-output folder.
 
@@ -160,11 +160,11 @@ class Actions:
         asset_helper = AssetHelper(org_config.get("id"))
         return self._add(
             asset_fullpath,
-            asset_helper.path_for(collection_id, "add", output=True),
+            asset_helper.path_for(collection_id, "c2pa-add", output=True),
             asset_helper,
         )
 
-    def update(self, asset_fullpath, org_config, collection_id):
+    def c2pa_update(self, asset_fullpath, org_config, collection_id):
         """Process asset with update action.
         A new asset file is generated in the update-output folder with a claim that links it to a parent asset identified by its filename.
 
@@ -182,11 +182,11 @@ class Actions:
         return self._update(
             asset_fullpath,
             _claim.generate_update(org_config, collection_id),
-            asset_helper.path_for(collection_id, "update", output=True),
+            asset_helper.path_for(collection_id, "c2pa-update", output=True),
             asset_helper,
         )
 
-    def store(self, asset_fullpath, org_config, collection_id):
+    def c2pa_store(self, asset_fullpath, org_config, collection_id):
         """Process asset with store action.
         The provided asset stored on decentralized storage, then a new asset file is generated in the store-output folder with a storage claim.
 
@@ -210,10 +210,10 @@ class Actions:
         return self._update(
             added_asset,
             _claim.generate_store(ipfs_cid.organization_id),
-            AssetHelper(organization_id).path_for(collection_id, "store", output=True),
+            AssetHelper(organization_id).path_for(collection_id, "c2pa-store", output=True),
         )
 
-    def custom(self, asset_fullpath, org_config, collection_id):
+    def c2pa_custom(self, asset_fullpath, org_config, collection_id):
         """Process asset with custom action.
         A new asset file is generated in the custom-output folder with a claim that links it to a parent asset identified by its filename.
 
@@ -244,7 +244,7 @@ class Actions:
         return self._update(
             added_asset,
             _claim.generate_custom(custom_assertions),
-            asset_helper.path_for(collection_id, "custom", output=True),
+            asset_helper.path_for(collection_id, "c2pa-custom", output=True),
             asset_helper,
         )
 

--- a/starlingcaptureapi/actions.py
+++ b/starlingcaptureapi/actions.py
@@ -3,7 +3,6 @@ from .claim import Claim
 from .claim_tool import ClaimTool
 from .encrypted_archive import EncryptedArchive
 from .filecoin import Filecoin
-from .file_util import FileUtil
 from .iscn import Iscn
 from . import config
 
@@ -39,7 +38,7 @@ class Actions:
             asset_fullpath: the local path to the asset file
             org_config: configuration dictionary for this organization
             collection_id: string with the unique collection identifier this
-                asset is in; might be None for legacy configurations
+                asset is in
 
         Raises:
             Exception if errors are encountered during processing
@@ -152,7 +151,7 @@ class Actions:
             asset_fullpath: the local path to the asset file
             org_config: configuration dictionary for this organization
             collection_id: string with the unique collection identifier this
-                asset is in; might be None for legacy configurations
+                asset is in
 
         Returns:
             the local path to the asset file in the internal directory
@@ -172,7 +171,7 @@ class Actions:
             asset_fullpath: the local path to the asset file
             org_config: configuration dictionary for this organization
             collection_id: string with the unique collection identifier this
-                asset is in; might be None for legacy configurations
+                asset is in
 
         Returns:
             the local path to the asset file in the internal directory
@@ -194,7 +193,7 @@ class Actions:
             asset_fullpath: the local path to the asset file
             org_config: configuration dictionary for this organization
             collection_id: string with the unique collection identifier this
-                asset is in; might be None for legacy configurations
+                asset is in
 
         Returns:
             the local path to the asset file in the internal directory
@@ -221,7 +220,7 @@ class Actions:
             asset_fullpath: the local path to the asset file
             org_config: configuration dictionary for this organization
             collection_id: string with the unique collection identifier this
-                asset is in; might be None for legacy configurations
+                asset is in
 
         Returns:
             the local path to the asset file in the internal directory
@@ -233,7 +232,7 @@ class Actions:
         added_asset = self._add(asset_fullpath, None)
 
         # Parse file name to get the search key.
-        file_name, file_extension = os.path.splitext(os.path.basename(added_asset))
+        file_name, _ = os.path.splitext(os.path.basename(added_asset))
 
         # Find custom assertions for file.
         custom_assertions = self._load_custom_assertions().get(file_name)

--- a/starlingcaptureapi/asset_helper.py
+++ b/starlingcaptureapi/asset_helper.py
@@ -97,30 +97,12 @@ class AssetHelper:
         self._init_collection_dirs()
 
         _logger.info(f"Initializing legacy action directories for {self.org_id}")
-        _file_util.create_dir(self.legacy_path_for("add"))
-        _file_util.create_dir(self.legacy_path_for("add", output=True))
-        _file_util.create_dir(self.legacy_path_for("store"))
-        _file_util.create_dir(self.legacy_path_for("store", output=True))
-        _file_util.create_dir(self.legacy_path_for("custom"))
-        _file_util.create_dir(self.legacy_path_for("custom", output=True))
-        # 'Create' files come via HTTP, there is no create folder
+        # 'Create' files come via HTTP, there are no "input" create folders
         _file_util.create_dir(self.legacy_path_for("create", output=True))
         _file_util.create_dir(self.legacy_path_for("create-proofmode", output=True))
 
     def get_assets_internal(self):
         return self.dir_internal_assets
-
-    def get_claims_internal(self):
-        return self.dir_internal_claims
-
-    def get_assets_internal_tmp(self):
-        return self.dir_internal_tmp
-
-    def get_assets_internal_create(self):
-        return self.dir_internal_create
-
-    def get_assets_internal_create_proofmode(self):
-        return self.dir_internal_create_proofmode
 
     def get_assets_create_output(self, subfolders=[]):
         return self._get_path_with_subfolders(
@@ -186,11 +168,6 @@ class AssetHelper:
 
         Appends `-output` if output=True.
         """
-        # Backwards-compatibility workaround for missing collection_ids.
-        # Can be removed once legacy paths are no longer in use.
-        if collection_id is None:
-            return self.legacy_path_for(action, output=output)
-
         return os.path.join(
             self._shared_collection_prefix(collection_id),
             f"{action}-output" if output else action,

--- a/starlingcaptureapi/asset_helper.py
+++ b/starlingcaptureapi/asset_helper.py
@@ -163,6 +163,10 @@ class AssetHelper:
             f"{action}-output" if output else action,
         )
 
+    def input_path_for(self, collection_id: str) -> str:
+        """Returns a full direction path for the input dir for this collection."""
+        return os.path.join(self._shared_collection_prefix(collection_id), "input")
+
     def path_for(self, collection_id: str, action: str, output: bool = False):
         """Retuns a full directory path for the given collection and action.
 
@@ -185,7 +189,9 @@ class AssetHelper:
 
     def _init_collection_dirs(self):
         _logger.info(f"Initializing collection directories for {self.org_id}")
-        collections_dict = config.ORGANIZATION_CONFIG.get(self.org_id).get("collections", {})
+        collections_dict = config.ORGANIZATION_CONFIG.get(self.org_id).get(
+            "collections", {}
+        )
         if len(collections_dict.keys()) == 0:
             _logger.info(f"No collections found for {self.org_id}")
             return
@@ -195,7 +201,10 @@ class AssetHelper:
                 raise ValueError(
                     f"Collection {coll_id} for org {self.org_id} is not filename safe"
                 )
+            _file_util.create_dir(self.input_path_for(coll_id))
             for action_name in coll_config.get("actions", {}).keys():
+                # This input path is a legacy path, and will be removed when all actions
+                # move to use the per-collection input directory
                 _file_util.create_dir(self.path_for(coll_id, action_name))
                 _file_util.create_dir(self.path_for(coll_id, action_name, output=True))
 

--- a/starlingcaptureapi/fs_watcher.py
+++ b/starlingcaptureapi/fs_watcher.py
@@ -65,7 +65,6 @@ class FsWatcher:
 
     def watch(self):
         """Start file watching handlers."""
-        self._schedule_legacy_handlers()
         for collection_id, collection_config in self.org_config.get(
             "collections", {}
         ).items():
@@ -100,28 +99,6 @@ class FsWatcher:
             ),
             recursive=True,
             path=self.asset_helper.path_for(collection_id, action),
-        )
-
-    def _schedule_legacy_handlers(self):
-        _logger.info(
-            "Setting up watcher handlers for legacy action directories of organization %s",
-            self.organization_id,
-        )
-        patterns = ["*.jpg", "*.jpeg"]
-        self.observer.schedule(
-            C2paAddHandler(patterns=patterns).with_config(self.org_config),
-            recursive=True,
-            path=self.asset_helper.legacy_path_for("add"),
-        )
-        self.observer.schedule(
-            C2paStoreHandler(patterns=patterns).with_config(self.org_config),
-            recursive=True,
-            path=self.asset_helper.legacy_path_for("store"),
-        )
-        self.observer.schedule(
-            C2paCustomHandler(patterns=patterns).with_config(self.org_config),
-            recursive=True,
-            path=self.asset_helper.legacy_path_for("custom"),
         )
 
 

--- a/tests/test_asset_helper.py
+++ b/tests/test_asset_helper.py
@@ -9,11 +9,6 @@ def test_rejects_non_file_safe_org():
         asset_helper.AssetHelper("not File Safe")
 
 
-def test_directory_contains_org():
-    helper = asset_helper.AssetHelper("example")
-    assert helper.get_claims_internal() == "/tests/assets_dir/example/claims"
-
-
 def test_create_output_contains_subfolders(monkeypatch, tmp_path):
     monkeypatch.setattr(config, "SHARED_FILE_SYSTEM", tmp_path / "shared_dir")
 

--- a/tests/test_asset_helper.py
+++ b/tests/test_asset_helper.py
@@ -36,9 +36,9 @@ def test_path_for(monkeypatch, tmp_path):
     monkeypatch.setattr(config, "SHARED_FILE_SYSTEM", tmp_path / "shared_dir")
 
     helper = asset_helper.AssetHelper("some-org")
-    assert helper.path_for("my-collection", "update").endswith(
-        "/shared_dir/some-org/my-collection/update"
+    assert helper.path_for("my-collection", "c2pa-update").endswith(
+        "/shared_dir/some-org/my-collection/c2pa-update"
     )
-    assert helper.path_for("my-collection", "update", output=True).endswith(
-        "/shared_dir/some-org/my-collection/update-output"
+    assert helper.path_for("my-collection", "c2pa-update", output=True).endswith(
+        "/shared_dir/some-org/my-collection/c2pa-update-output"
     )


### PR DESCRIPTION
Addresses https://github.com/starlinglab/starling-integrity-api/issues/65 and https://github.com/starlinglab/starling-integrity-api/issues/73.

This PR changes our configuration loading to conform to the new schema, including:
- creating sub-directories for each collection
- extracting `creative_work` information from the collection + action configuration; the collection is determined based on the asset path (although we could instead be passing the collection explicitly through everywhere)
- creating file watchers for each collection + action combination

I've kept untouched as much of the existing behavior, to try to make the migration to the new structure a little bit easier and to minimize the size of this already-large PR.

All existing actions, except for "update", can continue working with the "old style" directories ("update" is special in that it needs an input that is now coming from the per-collection-per-action parameters).

What are now the "legacy" directory paths can be cleaned up in follow-up changes and migrations, if and when needed.