### PR TITLE
Rename project in README to match new repo name

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.local/share/virtualenvs
-          key: ${{ runner.os }}-pipenv-${{ hashFiles('**/Pipfile.lock') }}
+          key: ${{ runner.os }}-pipenv-v1-${{ hashFiles('**/Pipfile.lock') }}
 
       - name: Install dependencies
         if: steps.cache-pipenv.outputs.cache-hit != 'true'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Starling Integrity API <!-- omit in toc -->
+# Starling Integrity Backend <!-- omit in toc -->
 
 - [Overview](#overview)
 - [Configuration](#configuration)
@@ -12,7 +12,7 @@
 
 ## Overview
 
-The Starling Integrity API provides HTTP endpoints for creating integrity attestations based on incoming data.
+The Starling Integrity Backend provides HTTP endpoints for creating integrity attestations based on incoming data.
 
 It depends on a binary of Adobe's `claim_tool`, which is planned to be open-sourced.
 


### PR DESCRIPTION
As part of the renaming for https://github.com/starlinglab/integrity-backend/issues/9, rename the project to "Integrity Backend" in the README, to match the new repo name.