### PR TITLE
Content metadata proofmode

### DIFF
--- a/integritybackend/actions.py
+++ b/integritybackend/actions.py
@@ -230,7 +230,7 @@ class Actions:
             # Register encrypted ZIP on ISCN
             if action_params["registration_policies"]["opentimestamps"]["active"]:
                 with open(extracted_meta_content) as meta_content_f:
-                    meta_content = json.load(meta_content_f)
+                    meta_content = json.load(meta_content_f)["contentMetadata"]
                     iscn_record = {
                         "contentFingerprints": [
                             f"hash://sha256/{enc_zip_sha}",
@@ -425,7 +425,7 @@ class Actions:
                 if meta_content_path is None:
                     raise Exception(f"ZIP at {zip_path} has no content metadata file")
                 with zipf.open(meta_content_path) as meta_content_f:
-                    meta_content = json.load(meta_content_f)
+                    meta_content = json.load(meta_content_f)["contentMetadata"]
                     photographer_id = asset_helper.filename_safe(
                         meta_content["private"]["signal"]["sourceName"]
                     )

--- a/integritybackend/actions.py
+++ b/integritybackend/actions.py
@@ -394,16 +394,6 @@ class Actions:
             action_name = "c2pa-proofmode"
             org_id = org_config["id"]
             asset_helper = AssetHelper(org_id)
-            _file_util = FileUtil()
-
-            # Get configs
-            collection = config.ORGANIZATION_CONFIG.get_collection(
-                org_id, collection_id
-            )
-            action = config.ORGANIZATION_CONFIG.get_action(
-                org_id, collection_id, action_name
-            )
-            action_params = action.get("params")
 
             # Get paths
             action_dir = asset_helper.path_for_action(collection_id, action_name)
@@ -463,7 +453,7 @@ class Actions:
             # C2PA-inject all JPEGs
             for filename in image_filenames:
                 claim = _claim.generate_c2pa_proofmode(
-                    action_params, meta_content, filename
+                    meta_content, filename
                 )
                 path = os.path.join(tmp_img_dir, filename)
                 _claim_tool.run_claim_inject(claim, path, None)

--- a/integritybackend/claim.py
+++ b/integritybackend/claim.py
@@ -98,17 +98,16 @@ class Claim:
         return claim
 
     def generate_c2pa_proofmode(
-        self, action_params: dict, meta_content: dict, filename: str
+        self, meta_content: dict, filename: str
     ):
         """Generates a claim for the 'c2pa-proofmode' action.
 
         Args:
-            action_params: a dictionary with the params from this action's config
-            meta_content: dictionary with the metadata from a proofmode bundle
-            filename:
+            meta_content: dictionary in the content metadata of a proofmode input zip
+            filename: filename of the JPG file in the proofmode bundle to generate this claim for
 
         Returns:
-            a dictionary containing the 'create' claim data
+            a dictionary containing the claim data
         """
         claim = copy.deepcopy(CREATE_CLAIM_TEMPLATE)
         claim["recorder"] = "ProofMode by Guardian Project and WITNESS"
@@ -123,8 +122,8 @@ class Claim:
             author_data["credential"] = []
             assertions.append(creative_work)
 
-        author_name = action_params["creative_work_author"]["name"]
-        copyright = action_params["copyright"]
+        author_name = meta_content["author"]["name"]
+        copyright = meta_content["copyright"]
         gps_lat = meta_content["private"]["proofmode"][filename]["proofs"][0][
             "Location.Latitude"
         ]


### PR DESCRIPTION
This adds the `contentMetadata` container to bring us back to spec. It also take copyright and author from content (instead of action config).

I am also making the parsing more robust to missing fields, such as `copyright`. GPS however is still required.

I forget if we need to do something about the `Z` to not falsely signify UTC when we only know local time?

        gps_time = (
            datetime.utcfromtimestamp(
                int(proofmode_data["proofs"][0]["Location.Time"]) / 1000
            ).isoformat()
            + "Z"
        )
```