### PR TITLE
Add copy-proofmode action

### DIFF
--- a/integritybackend/fs_watcher.py
+++ b/integritybackend/fs_watcher.py
@@ -154,6 +154,14 @@ class C2paProofmodeHandler(OrganizationHandler):
             _actions.c2pa_proofmode(event.src_path, self.org_config, self.collection_id)
 
 
+class CopyProofmodeHandler(OrganizationHandler):
+    """Handles file changes for Copy Proofmode action."""
+
+    def on_created(self, event):
+        with caught_and_logged_exceptions(event):
+            _actions.copy_proofmode(event.src_path, self.org_config, self.collection_id)
+
+
 # class C2paAddHandler(OrganizationHandler):
 #     """Handles file changes for add action."""
 
@@ -191,6 +199,7 @@ ACTION_HANDLER = {
     "archive": ArchiveHandler,
     "c2pa-starling-capture": C2paStarlingCaptureHandler,
     "c2pa-proofmode": C2paProofmodeHandler,
+    "copy-proofmode": CopyProofmodeHandler,
     # "c2pa-add": C2paAddHandler,
     # "c2pa-update": C2paUpdateHandler,
     # "c2pa-store": C2paStoreHandler,


### PR DESCRIPTION
This adds a new `copy-proofmode` action that extracts all data to an output folder sync'd to Dropbox.

- [ ] @YurkoWasHere you'll have to sync the config from spreadsheet again bc I realized that I mis-named the action. It should be `copy-proofmode`, and I put `move-` in the JSON generation before.
- [ ] To your question of a "staging config", I wonder if it's sufficient to make these sign with staging domain, and we only use these for internal testing:

    <img width="432" alt="Screen Shot 2022-05-15 at 12 15 12 PM" src="https://user-images.githubusercontent.com/2261308/168467840-1e936fb8-83be-42b3-b7b5-1e885d89338b.png">

    As for public testing, like trial runs with partners, it's probably okay to sign with production certs? If so, please change the domains in spreadsheet to stg signers.